### PR TITLE
termbench: Compiling for Mac M1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a simple benchmark you can use to see how your terminal sinks large outp
 On slow terminals, you will want to run termbench like this:
 
 ```
-termbench small
+termbench_release_clang small
 ```
 
 This will run very small data sizes (~1 megabyte) so that the terminal has a prayer of completing the benchmark in a reasonable amount of time.  This is the recommended setting for things like cmd.exe or Windows Terminal.
@@ -15,13 +15,13 @@ This will run very small data sizes (~1 megabyte) so that the terminal has a pra
 For terminals that have reasonable performance, you run it like this:
 
 ```
-termbench
+termbench_release_clang
 ```
 
 for the regular benchmark sizes, or like this
 
 ```
-termbench large
+termbench_release_clang large
 ```
 
 for larger benchmark sizes (if you want more of a stress test than normal).

--- a/termbench.cpp
+++ b/termbench.cpp
@@ -114,11 +114,10 @@ static void PreparePlatform(platform_values *Result)
 #elif __APPLE__
     size_t CpuStringLen = sizeof(Result->CPUString);
 
-    // Writes out a product model and version - mapping this to a specific silicon chip is left as an exercise for the user.
-    // However, we know it's Arm ("Apple Silicon"), or we'd have take the above cpuid branch.
-    // Example: An M1 MacBookAir reports "MacBookAir10,1"
+    // Writes out the CPU brand.
+    // Example: On an M1 Mac this would be "Apple M1"
     sysctlbyname(
-                 "hw.model",
+                 "machdep.cpu.brand_string",
                  Result->CPUString,
                  &CpuStringLen,
                  NULL, // nNewVal


### PR DESCRIPTION
This PR adds support for M1 Macs. I have extracted the process of obtaining the CPU name into a
separate function to make a little bit more clean as the M1 doesn't need the loop.
I also omitted the inclusion of cpuid.h in case of M1 as it was throwing a compiler error "This is only for x86".
I guess that this has only inline asm for intel cpus.

Edit: I didn't know if I should open this PR against master or V3 so I went with master. If you want me to change that, feel free to tell me :)