### PR TITLE
Add Croatian translation

### DIFF
--- a/termbench_message.h
+++ b/termbench_message.h
@@ -13,6 +13,7 @@ const char *EndingMessage =
   u8"Você pode acordar alguém que está dormindo, mas não alguém que finge estar dormindo.\n"
   u8"Можно разбудить того кто спит, но не того кто притворяется спящим.\n"
   u8"Можеш да пробудиш оног који спава, али не оног који се претвара да спава.\n"
+  u8"Možeš probuditi onog koji spava, ali ne onog koji se pretvara da spava.\n"
   u8"Îl poți trezi pe omul care doarme, dar nu și pe cel care se preface că doarme.\n"
   u8"Du kan väcka den som sover, men inte den som låtsas sova.\n"
 ;


### PR DESCRIPTION
It does not add many diacritics.
I could formulate it in a way that adds more but it be less natural.
"onog koji spava" would then be "spavajućeg".