### PR TITLE
Fix gibibyte symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ for larger benchmark sizes (if you want more of a stress test than normal).
 
 # Expected Results
 
-On modern Windows machines with memory bandwidth in the 10-20gb/s range, the expected throughput for these tests would be in the 0.5-2.0gb/s range for a reasonable terminal.  Numbers significantly higher than that might indicate a well-optimized terminal, and numbers significantly lower than that might indicate a poorly written terminal.
+On modern Windows machines with memory bandwidth in the 10-20 GiB/s range, the expected throughput for these tests would be in the 0.5-2.0 GiB/s range for a reasonable terminal.  Numbers significantly higher than that might indicate a well-optimized terminal, and numbers significantly lower than that might indicate a poorly written terminal.
 
 Termbench has not yet been tested on Linux, so we do not have expected bandwidth numbers at this time.
 

--- a/termbench.cpp
+++ b/termbench.cpp
@@ -406,7 +406,7 @@ int main(int ArgCount, char **Args)
         AppendDouble(&Frame, Context.SecondsElapsed);
         AppendString(&Frame, "s (");
         AppendDouble(&Frame, GetGBS((double)Context.TotalWriteCount, Context.SecondsElapsed));
-        AppendString(&Frame, "gb/s)\n");
+        AppendString(&Frame, " GiB/s)\n");
 
         TotalSeconds += Context.SecondsElapsed;
         TotalBytes += Context.TotalWriteCount;
@@ -419,7 +419,7 @@ int main(int ArgCount, char **Args)
     AppendDouble(&Frame, TotalSeconds);
     AppendString(&Frame, "s (");
     AppendDouble(&Frame, GetGBS((double)TotalBytes, TotalSeconds));
-    AppendString(&Frame, "gb/s)\n");
+    AppendString(&Frame, " GiB/s)\n");
 
     RawFlushBuffer(OutputHandle, &Frame);
 }


### PR DESCRIPTION
1. Avoid bit/byte confusion
IEC 60027 specifies that the symbol for binary digit should be 'bit',
and this should be used in all multiples, such as 'kbit', for kilobit.
However, the lower-case letter 'b' is widely used as well and was
recommended by the IEEE 1541 Standard (2002).

2. Also avoid "giga" confusion.
Giga according to SI is abbreviated as uppercase G and means 10^6.
Termbench uses binary units (1024^n) therefore this should be written as
Gi (gibi)