### PR TITLE
added compatibility for mac hardware with arm processors

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+BaseFile=termbench.cpp
+
+CLANG=$(which clang++)
+if [[ -x "${CLANG}" ]]
+then
+  CLLinkFlags="-Wformat"
+  CLCompileFlags="-O3 -Ofast"
+  CC="${CLANG}"
+  output=termbench_release_clang
+else
+	echo "ABORTING: no compiler detected"
+fi
+
+if [[ -x "${CC}" ]]
+then
+  echo Building release: ./${output}
+  "${CC}" -O3 ${CLCompileFlags} ${CLLinkFlags} ${BaseFile} -o "${output}"
+  strip "${output}"
+fi


### PR DESCRIPTION
- created a build.sh (can be used for Mac or Linux)
- modified termbench because cpuid.h is not available on MacOS